### PR TITLE
Fixing Errors on showing wrong deductions on figures of between 4,500…

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,21 @@
+body{
+	font-family: cursive;
+    font-size: 14px;
+}
+
+h2, h4{
+	text-align: center;
+}
+
+button:hover{
+	font-weight: bold;
+}
+
+input[type=number]:focus
+{
+	font-weight: bold;
+}
+
+.card-body {
+    box-shadow: var(--shd, 0 5px 10px rgba(0, 0, 0, .6));
+}

--- a/js/payeCalc.js
+++ b/js/payeCalc.js
@@ -1,0 +1,69 @@
+// Module initialisation connected to the PAYE tax HTML app
+var app = angular.module("payeApp", []);
+
+app.controller("myCtrl", ($scope) => {
+    $scope.paye_calc = () => {
+
+        // - g_amount as gross amount upon which PAYE amount is calculated on
+        const g_amount = Number($scope.gross_amount);
+
+        /* 
+        - PAYE is calculated in bracket amount listed below
+        - amount below and equal to 4500, amounts are PAYE free
+        - other bands listed below are used to calculate PAYE depending on employee gross pay
+        */
+        const paye_1st_band = 4500.00;
+        const paye_2nd_lower_band = 4500.01;
+        const paye_2nd_higher_band = 4800;
+        const paye_3rd_lower_band = 4800.01;
+        const paye_3rd_higher_band = 6900.00;
+
+        // Condition statement below check if g_amount with within the bracket defined above
+        //Check if the amount is less than K4,500
+        if (g_amount <= paye_1st_band) {
+            $scope.lower_1st_bracket = paye_1st_band;
+            $scope.perc_0 = $scope.lower_1st_bracket * 0.00;
+            $scope.perc_1 = $scope.lower_1st_bracket * 0.00;
+            $scope.perc_2 = $scope.lower_1st_bracket * 0.00;
+            $scope.perc_3 = $scope.lower_1st_bracket * 0.00;;
+        }
+
+ //Check if the amount is greater than K4500 but less than k4,800
+        if (g_amount >= paye_2nd_lower_band && g_amount <= paye_2nd_higher_band ) {
+            $scope.lower_2nd_bracket = g_amount - paye_2nd_lower_band;
+            $scope.perc_0 = 0.00;
+            $scope.perc_1 =$scope.lower_2nd_bracket * 0.25;
+            $scope.perc_2 = 0.00;
+            $scope.perc_3 = 0.00;
+
+        }
+
+       
+
+ //Check if the amount is greater than K4800 but less than k6,900
+        if (g_amount >=  paye_3rd_lower_band && g_amount <= paye_3rd_higher_band ) {
+            $scope.lower_3rd_bracket = g_amount - paye_2nd_higher_band;
+            $scope.perc_0 = 0.00
+            $scope.perc_1 = 75;
+            $scope.perc_2 =$scope.lower_3rd_bracket * 0.3;
+            $scope.perc_3 = $scope.lower_1st_bracket * 0.00;
+
+        }
+
+
+ //Check if the amount is greater than K6,900
+ if (g_amount > paye_3rd_higher_band ) {
+    $scope.lower_4th_bracket = g_amount - paye_3rd_higher_band;
+    $scope.perc_0 = 0.00;
+    $scope.perc_1 = 75;
+    $scope.perc_2 = 630;
+    $scope.perc_3 =   $scope.lower_4th_bracket * 0.375;
+
+}
+
+
+
+
+       
+    }
+});

--- a/paye-calculator.html
+++ b/paye-calculator.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <title>PAYE Calculator</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.9/angular.min.js"></script>
+    <link rel="stylesheet" href="css/style.css">
+    <script src="js/payeCalc.js"></script>
+</head>
+
+<body>
+    <div class="container mt-3">
+        <center><h3>Pay As You Earn Calculator</h3></center>
+        <br>
+        <div class="shadow-lg p-3 mb-5 bg-white rounded">
+            
+                <div class="container mt-3" ng-app="payeApp" ng-controller="myCtrl">
+                    <h4>0 - 4,500: <span>{{ perc_0 | currency : "ZMW " :  2}}</span></h4>
+                    <h4>4,500.01 - 4,800: <span>{{ perc_1 | currency : "ZMW " : 2 }}</span></h4>
+                    <h4>4,800.01 - 6,900: <span>{{ perc_2 | currency : "ZMW " : 2}}</span></h4>
+                    <h4>Above 6,900: <span>{{ perc_3 | currency : "ZMW " : 2}}</span></h4>
+                    <br>
+                    <div class="form-floating mb-3 mt-3">
+                        <input id="grosspay" type="number" class="form-control" placeholder="Gross Amount" ng-model="gross_amount" ng-change="paye_calc()">
+                        <label for="amount">Gross Amount</label>
+                    </div>
+                    <br>
+                    <div class="d-grid gap-3">
+                        <div class="btn btn-success" onclick="document.getElementById('grosspay').value = ''" >Clear Field
+                    </div>
+                    <hr>
+
+                </div>            
+        </div>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
Fixing Errors on showing wrong deductions on figures of between K4,500.01 and K6,800. The computation is showing that if a person gets a salary of K4,600 for example or 5000 or any salary less than K6,800 he/she will be deducted an amount of K630 at a certain point as part of payee. This is not correct with reference to the ZRA Payee calculator computation bands.(https://www.zra.org.zm/calculate-paye/). Also on clearing input fields used JavaScript which will not enable a page to reload.  